### PR TITLE
Use 2.5.0.0 pdk docker image as newer version fails

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG PDKIMAGE=puppet/pdk:latest
+ARG PDKIMAGE=puppet/pdk:2.5.0.0
 
 FROM $PDKIMAGE
 


### PR DESCRIPTION
- Fix #3 
- We can relies on pdk-image args as it does not work (see #4 )